### PR TITLE
Title bar problem.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+dist/
+node_modules/
+yarn.lock
+
+.*.swp
+.*.swo

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function createWindow () {
     height: 600,
     minWidth: 300,
     minHeight: 300,
-    frame: false,
+    frame: true,
     title: "Apple Music",
   // Enables DRM
     webPreferences: {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function createWindow () {
     height: 600,
     minWidth: 300,
     minHeight: 300,
-    frame: false,
+    frame: true,
     title: "Apple Music",
   // Enables DRM
     webPreferences: {
@@ -63,13 +63,14 @@ function createWindow () {
     }
   });
 
+  /*
   // Hide iTunes prompt and other external buttons by Apple. Ensure deletion. Create Draggable div to act as title bar. Create close, min, and max buttons. (OSX style since this is *Apple* Music)
   win.webContents.on('did-stop-loading', function() {
     win.webContents.executeJavaScript("const elements = document.getElementsByClassName('web-navigation__native-upsell'); while (elements.length > 0) elements[0].remove();");
     win.webContents.executeJavaScript("while (elements.length > 0) elements[0].remove();");
     win.webContents.executeJavaScript("if(document.getElementsByClassName('web-navigation')[0] && !(document.getElementsByClassName('web-navigation')[0].style.height == 'calc(100vh - 32px)')){ let dragDiv = document.createElement('div'); dragDiv.style.width = '100%'; dragDiv.style.height = '32px'; dragDiv.style.position = 'absolute'; dragDiv.style.top = dragDiv.style.left = 0; dragDiv.style.webkitAppRegion = 'drag'; document.body.appendChild(dragDiv); var closeButton = document.createElement('span'); document.getElementsByClassName('web-navigation')[0].style.height = 'calc(100vh - 32px)'; document.getElementsByClassName('web-navigation')[0].style.bottom = 0; document.getElementsByClassName('web-navigation')[0].style.position = 'absolute'; document.getElementsByClassName('web-chrome')[0].style.top = '32px'; var minimizeButton = document.createElement('span'); var maximizeButton = document.createElement('span'); document.getElementsByClassName('web-navigation')[0].style.height = 'calc(100vh - 32px)'; closeButton.style = 'height: 11px; width: 11px; background-color: rgb(255, 92, 92); border-radius: 50%; display: inline-block; left: 0px; top: 0px; margin: 10px 4px 10px 10px; color: rgb(130, 0, 5); fill: rgb(130, 0, 5); -webkit-app-region: no-drag; '; minimizeButton.style = 'height: 11px; width: 11px; background-color: rgb(255, 189, 76); border-radius: 50%; display: inline-block; left: 0px; top: 0px; margin: 10px 4px; color: rgb(130, 0, 5); fill: rgb(130, 0, 5); -webkit-app-region: no-drag;'; maximizeButton.style = 'height: 11px; width: 11px; background-color: rgb(0, 202, 86); border-radius: 50%; display: inline-block; left: 0px; top: 0px; margin: 10px 10px 10px 4px; color: rgb(130, 0, 5); fill: rgb(130, 0, 5); -webkit-app-region: no-drag;'; closeButton.onclick= window.close; minimizeButton.onclick = ()=>{ipcRenderer.send('minimize')}; maximizeButton.onclick = ()=>{ipcRenderer.send('maximize')}; dragDiv.appendChild(closeButton); dragDiv.appendChild(minimizeButton); dragDiv.appendChild(maximizeButton); closeButton.onmouseenter = ()=>{closeButton.style.filter = 'brightness(50%)'}; minimizeButton.onmouseenter = ()=>{minimizeButton.style.filter = 'brightness(50%)'}; maximizeButton.onmouseenter = ()=>{maximizeButton.style.filter = 'brightness(50%)'}; closeButton.onmouseleave = ()=>{closeButton.style.filter = 'brightness(100%)'}; minimizeButton.onmouseleave = ()=>{minimizeButton.style.filter = 'brightness(100%)'}; maximizeButton.onmouseleave = ()=>{maximizeButton.style.filter = 'brightness(100%)'};}")
 
-  });
+  });*/
 
   // Fix those ugly scrollbars and also execute MusicKitInterop.
   win.webContents.once('did-stop-loading', async () => {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function createWindow () {
     height: 600,
     minWidth: 300,
     minHeight: 300,
-    frame: true,
+    frame: false,
     title: "Apple Music",
   // Enables DRM
     webPreferences: {

--- a/install-deb.sh
+++ b/install-deb.sh
@@ -1,0 +1,28 @@
+#!/bin/bash 
+
+# check if yarn is installed, if not, install
+if ! yarn --version &> /dev/null
+then 
+  echo -e "\nYarn is not detected, installing\n"
+  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  sudo apt update
+  sudo apt install yarn -y
+  echo -e "\nYarn installed\n"
+fi 
+
+echo "Yarn is installed, continuing"
+
+
+echo -e "\n===== Installing =====\n"
+
+yarn install
+
+echo -e "\n===== Building =====\n"
+
+yarn dist
+
+my_file=$(find dist/*.deb)
+sudo dpkg -i $my_file
+
+echo -e "\nInstall Complete"


### PR DESCRIPTION
After first launch, when logging in, at least on Ubuntu, there was no title bars  etc. 
I think, this change fixed it:

```js
frame: true
```
Although it removes custom title bar, it is less buggy. I also experienced that the buttons on title bar besides the closing one didn't work. Well, now when title bar is shell default everything works fine.


Another change is implemeting the `install-deb.sh` script. It checks if you have the deps, if not it installs them. In case I missed something please add it or tell me.

I was thinking about adding install instructions to the documentation. But I don't know about that, please tell what do you think.