### PR TITLE
fix: Cache folder being misplaced for Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ let isQuiting
 let isMaximized
 electron.app.commandLine.appendSwitch("enable-transparent-visuals");
 
+// Set proper cache folder
+app.setPath("userData", path.join(app.getPath("cache"), app.name))
+
 // Optional Features
 const customtitlebar = true // NOTE: Enables a custom macOS-isk titlebar instead of your respected platforms titlebars. Enable frame manually if disabled. (true by default)
 const discordrpc = true // NOTE: Removes all Discord RPC when disabled. (true by default)


### PR DESCRIPTION
On Linux Chromium and by that extent Electron apps store a lot of their cache files in the `.config` folder, which is wrong from the sides of the XDG spec.

Furthermore it makes your `.config` folder way bigger than it has to be, usually my `.config` would be around 100MB at best, however as an example is Discord's cache which fills up 748MB. However I've it symlinked to a folder in `.cache` which is tedious and annoying to do.

This pr fixes that and sets it properly. I don't use AME just briefly found it checked it out, when uninstalling I had to remove the cache folder and thought "hey why not make a pr"